### PR TITLE
Fix/gitignore imagesfolder

### DIFF
--- a/grav/.gitignore
+++ b/grav/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .DS_Store
 .tmp
 /cache
+/images
+/images/*


### PR DESCRIPTION
/grav/images folder should not be tracked with this change.

To test:
If you do $ git status, /grav/images folder should not be shown as changed.