### PR TITLE
BA-31:  Changes in block "Sea parte del cambio"

### DIFF
--- a/grav/user/themes/azul/src/sass/partials/components/winners-page/_index.scss
+++ b/grav/user/themes/azul/src/sass/partials/components/winners-page/_index.scss
@@ -8,11 +8,11 @@
   width: 50%;
 
   h1 {
-    color: $c-blue; 
+    color: $c-blue;
     padding-bottom: 3%;
   }
-    
-} 
+
+}
 
 .intro-winners-info {
   font-family: $body-font;
@@ -39,10 +39,10 @@
   background-size: cover;
 
   h1 {
-    color: $c-blue; 
+    color: $c-blue;
     padding-bottom: 3%;
   }
-    
+
 }
 
 .indicators {
@@ -50,7 +50,7 @@
   padding: 10% 0;
   display: flex;
   justify-content: flex-end;
-  
+
   ul {
     padding: 0;
   }
@@ -59,13 +59,13 @@
     display: flex;
     margin-left: 10%;
     background-color: $c-green;
-    border: 8px solid #AEE8AD;     
+    border: 8px solid #AEE8AD;
     color: white;
     align-items: center;
     justify-content: center;
     width: 20%;
     padding: 5% 0;
-  
+
     p {
       position: absolute;
       margin-top: 10%;
@@ -89,27 +89,46 @@
 
 .know-how-to-apply-section {
   color: #fff;
-  padding: 7% 0;
   margin-top: 9%;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  padding: 20px;
+  @media screen and (min-width: $large) {
+    padding: 7% 0;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+  @media screen and (min-width: $large) {
+    max-width: 90%;
+    margin: 0 auto;
+  }
+
+  @media screen and (min-width: $x-large) {
+    max-width: 950px;
+  }
 
   p {
-    font-size: 25px;
-    color: #fff;
-  }
-
-  a {
     font-size: 20px;
+    color: #fff;
+    margin-bottom: 10px;;
+    @media screen and (min-width: $large) {
+      font-size: 25px;
+      margin-bottom: 0;
+    }
+    @media screen and (min-width: $large) {
+      padding-right: 20px;
+    }
   }
-  
+
+  .button {
+    font-size: 17px;
+    padding: 10px 44px 10px 25px;
+    font-weight: bold;
+    white-space: nowrap;
+    @media screen and (min-width: $medium) {
+      font-size: 20px;
+      padding: 13px 50px;
+    }
+  }
+
 }
-
-
-
-
-
-
-
-

--- a/grav/user/themes/azul/templates/winners.html.twig
+++ b/grav/user/themes/azul/templates/winners.html.twig
@@ -9,7 +9,7 @@
 					<h1>{{ header.title }}</h1>
 					<h2>{{ header.summary_winners }}</h2>
 					<h2>{{ header.summary_time_winners }}</h2>
-					<img class="header-winners-image"src='{{ (header.winners_image|first).path }}'>	
+					<img class="header-winners-image"src='{{ (header.winners_image|first).path }}'>
 				</div>
 				<div class="intro-winners-info">
 					{{ page.content }}
@@ -26,7 +26,7 @@
 				<div class="circle-indicator">
 					<span>{{ header.kpi_first }}</span>
 					<p>Aumento de participantes</p>
-				</div> 
+				</div>
 				<div class="circle-indicator">
 					<span>{{ header.kpi_second }}</span>
 					<p>Aumento de ganadores</p>
@@ -39,16 +39,16 @@
 							<li>{{ header.thirdCategory }}</li>
 						</ul>
 					</span>
-					<p>Categorías con más galardones</p>	
-				</div>						
-			</div>	
+					<p>Categorías con más galardones</p>
+				</div>
+			</div>
 		</div>
 	</div>
 	<div class="section-pattern section-pattern-green">
 		<div class="limiter">
 			<div class="know-how-to-apply-section">
-				<p><b> Sea parte del cambio <br> con Bandera Azul Ecológica Costa Rica</b></p>
-				<a class="button button-white" href="#"><b>Conozca como aplicar</b></a>
+				<p><b> Sea parte del cambio <br> con Bandera Azul Ecológica Costa Rica</b></p>
+				<a class="button button-white" href="#">Conozca cómo aplicar</a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
trello card:
https://trello.com/c/yBzBlAUp/37-ba-31-bloque-sea-parte-del-cambio

How to test:
- go to bae/grav/galardonados
- see the last block in the page for "Sea parte del cambio con Bandera Azul Ecológica Costa Rica"
- Should look like this:

Mobile:
![screen shot 2017-12-09 at 11 31 01 am](https://user-images.githubusercontent.com/1081264/33797841-81c1980c-dcd4-11e7-9b40-0041336e6762.png)

Tablet:
![screen shot 2017-12-09 at 11 31 16 am](https://user-images.githubusercontent.com/1081264/33797842-86d4e47a-dcd4-11e7-9534-8eb46672dec8.png)

Desktop:
![screen shot 2017-12-09 at 11 31 25 am](https://user-images.githubusercontent.com/1081264/33797843-8a41df3c-dcd4-11e7-98b5-030871a53cd9.png)
